### PR TITLE
feat: add compiler image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ before_install:
 - echo ${DOCKER_PASSWORD} | docker login -u=decaftravis --password-stdin
 install:
 - docker build -t ${IMAGE_REPO}:${IMAGE_HASH_TAG} -t ${IMAGE_REPO}:${IMAGE_TAG} ./alpine
+- docker build -t ${IMAGE_REPO}:compiler ./compiler
 script:
 - echo "Building image was successful!"
 after_success:
 - docker push ${IMAGE_REPO}:${IMAGE_HASH_TAG}
 - docker push ${IMAGE_REPO}:${IMAGE_TAG}
+- docker push ${IMAGE_REPO}:compiler
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ before_install:
 - echo ${DOCKER_PASSWORD} | docker login -u=decaftravis --password-stdin
 install:
 - docker build -t ${IMAGE_REPO}:${IMAGE_HASH_TAG} -t ${IMAGE_REPO}:${IMAGE_TAG} ./alpine
-- docker build -t ${IMAGE_REPO}:compiler ./compiler
+- docker build -t ${IMAGE_REPO}:compiler -t ${IMAGE_REPO}:compiler-${IMAGE_HASH_TAG} ./compiler
 script:
 - echo "Building image was successful!"
 after_success:
 - docker push ${IMAGE_REPO}:${IMAGE_HASH_TAG}
 - docker push ${IMAGE_REPO}:${IMAGE_TAG}
 - docker push ${IMAGE_REPO}:compiler
+- docker push ${IMAGE_REPO}:compiler-${IMAGE_HASH_TAG}
 notifications:
   email: false
   slack:

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -21,7 +21,7 @@ COPY sql-requirements.in ./
 RUN set -eux \
     # Install build dependencies to make sure we can build packages that don't
     # provide pre-built wheels from source.
-    && apk add --no-cache --virtual .build-deps g++ postgresql-dev \
+    && apk add --no-cache --virtual .build-deps build-base postgresql-dev \
     # Install postgres libs for psycopg2. Note that these are needed at runtime.
     && apk add --no-cache postgresql \
     # Compile the dependencies for base + SQL.

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux \
     # Pre-install the compiled requirements to save some build time for child
     # images.
     && pip-sync sql-requirements.txt \
-    # Remove build dependencies and pip cache to reduce layer size. Note that
-    # the pip-tools cache is kept to speed up `pip-compile` in child images.
+    # Remove build dependencies and the pip cache to reduce layer size.
     && apk del .build-deps \
-    && rm -rf /root/.cache/pip
+    && rm -rf /root/.cache

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,0 +1,9 @@
+FROM dddecaf/postgres-base:master
+
+RUN set -eux \
+    # Install build tools. These can be required for the `pip-compile` step in
+    # child images that require to build packages from source.
+    && apk add g++ postgresql-dev \
+    # Re-run pip-compile in order to pre-populate the pip cache.
+    && pip-compile --generate-hashes --output-file /dev/null \
+      /opt/sql-requirements.txt

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -3,7 +3,7 @@ FROM dddecaf/postgres-base:master
 RUN set -eux \
     # Install build tools. These can be required for the `pip-compile` step in
     # child images that require to build packages from source.
-    && apk add g++ postgresql-dev \
+    && apk add build-base postgresql-dev \
     # Re-run pip-compile in order to pre-populate the pip cache.
     && pip-compile --generate-hashes --output-file /dev/null \
       /opt/sql-requirements.txt


### PR DESCRIPTION
The compiler image contains build tools and the pip cache, and can be
used to perform `pip-compile` in child services.